### PR TITLE
add install instructions for setting up using vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 data/
 *.pyc
 .ipynb_checkpoints/
+.vagrant

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,12 +9,12 @@ This is the easiest way to get the code up and running on any platform that can 
 From the command line:
 
 1. Clone the project repository from GitHub to your local environment:
-        $ git clone git@github.com:18F/data-act-workshop.git  
+        $ git clone git@github.com:18F/intercessor.git
     **note:** if you don't have a GitHub account and want to get a read-only version of the code, use this command instead:  
-        $ git clone git://github.com/18F/data-act-workshop.git
+        $ git clone git://github.com/18F/intercessor.git
 
 2. Change to the project directory:  
-        $ cd data-act-workshop
+        $ cd intercessor
 
 3. Unzip a copy of the data directory and files. These aren't included with the code because they contain PII (personally identifiable information). We're working on putting up a secure cloud version that can be accessed by credentialed users, but for now:
     * Request a secure transmission of the data.zip file from a member of the project team.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,59 @@
+# Installation
+
+The following installation steps should work for Windows, Mac, and Linux.
+
+## Using VirtualBox and Vagrant
+
+This is the easiest way to get the code up and running on any platform that can run [VirtualBox](https://www.virtualbox.org/ "VirtualBox") virtualization software.
+
+From the command line:
+
+1. Clone the project repository from GitHub to your local environment:
+        $ git clone git@github.com:18F/data-act-workshop.git  
+    **note:** if you don't have a GitHub account and want to get a read-only version of the code, use this command instead:  
+        $ git clone git://github.com/18F/data-act-workshop.git
+
+2. Change to the project directory:  
+        $ cd data-act-workshop
+
+3. Unzip a copy of the data directory and files. These aren't included with the code because they contain PII (personally identifiable information). We're working on putting up a secure cloud version that can be accessed by credentialed users, but for now:
+    * Request a secure transmission of the data.zip file from a member of the project team.
+    * Copy data.zip to the project's root directory and unzip it. The resulting directory structure should look like this:
+
+          intercessor
+            /assets
+            /data
+              /jaams
+                AP_CHECKS_ALL.txt
+                AP_INVOICE_DISTRIBUTIONS_ALL.txt
+                ...
+                /sql
+              /prism
+                association.txt
+                cfda.txt
+                ...
+                /sql
+            /mappings
+            /processor
+            /schema
+            .gitignore
+            ...
+
+4. Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads "VirtualBox downloads")  
+
+5. Install [Vagrant](http://www.vagrantup.com/downloads.html "Vagrant downloads")  
+
+6. From project root directory, run:
+
+         $ vagrant up
+
+7. Once the VM is fully started and provisioned (~15 minutes), connect to it with:
+
+        $ vagrant ssh
+
+8. The project directory on your host machine is shared with the VM at `/vagrant`. Navigate there to run the processor.
+
+        $ cd /vagrant
+        $ workon intercessor
+
+Because the project directory on your host machine is shared with the VM, you can use your existing tools (IDE, browser, etc.) and everything will be synced with the VM.

--- a/README.md
+++ b/README.md
@@ -1,29 +1,52 @@
 # Intercessor
-Yet another DATA Act repository. This one contains code that translates agency data to a uniform DATA act format.
+This DATA Act repository contains the code for a small pilot project that translates financial and awards data from the Small Business Administration to a uniform DATA act format.
+
+Progress and upcoming work are viewable on our Github/Waffle-based task board: https://waffle.io/18F/intercessor
+
+Below is an overview of the process.
+
+![Intercessor Process Flow](https://raw.githubusercontent.com/18F/intercessor/master/intercessor-flow.png)
+
+## Glossary
+* **JAAMS**: SBA's financial system  
+* **Prism**: SBA's grants and contracts system  
+* **SAM**: Federal government-wide system that contains information about entities (businesses, individuals, or government agencies) that do business with the federal government. SAM stands for _System for Award Management_.  
+* **DATA Act Schema (_Schema_)**: The generic model of the relationships between the data elements that agencies must report to Treasury as part of the DATA Act and previous transparency legislation.  
+
+## Resources
+Here's a list of DATA Act resources and artifacts that might be useful to people working on this pilot:
+
+* [Finalized data element definitions](http://fedspendingtransparency.github.io/dataelements/ "Federal Spending Transparency Data Elements").
+* [In-progress data element definitions](http://fedspendingtransparency.github.io/data-exchange-standard/ "Collaboration Space: Federal Spending Data Elements"). For elements on this list that have been finalized, use the finalized version of the definition.
+* [Working DATA Act award-level schema](https://raw.githubusercontent.com/18F/intercessor/master/schema/data-act-schema.png "Draft DATA Act award-level schema diagram"). Because the official draft of the award-level DATA Act schema has not yet been published, we created this working copy to use for the pilot. **This is not an official version/draft of the DATA Act schema**.
+* Mapping document. This is the document that maps specific SBA JAAMS and Prism attributes to their DATA Act schema counterparts. It's not currently public and resides in the data folder.
+* [SBA Entity Relationship Diagram](https://raw.githubusercontent.com/18F/intercessor/master/assets/images/jaams-prism-data-act-mapping.png "SBA ERD"). A diagram of the relationships between the JAAMS and Prism tables that contain the fields being mapped to the DATA Act schema.
+* [Research Questions](https://github.com/18F/intercessor/labels/research%20questions "open issues labeled as 'research'"). Questions (and some answers) that have emerged during the pilot. Closed (_i.e._, answered) questions are [here](https://github.com/18F/intercessor/issues?q=label%3A%22research+questions%22+is%3Aclosed "closed issues labeled as 'research'").
+* [DATA Act Playbook](https://www.usaspending.gov/Documents/Summary%20of%20DATA%20Act%20Playbook.pdf "DATA Act Playbook"). Recommended steps for agencies to fulfill DATA Act requirements.
 
 ## Data
-Because it contains PII, the Small Business Administration (SBA) data used for this project is not included in the code repository. The data includes:
+For the first iterations of this pilot, we're using SBA 2014 grants data.
 
-* Extracts from JAAMS, the financial system that includes a record of SBA's payments
-* Exracts from Prism, the Oracle Financial System that contains information about SBA awards (grants, loans, and contracts)
+Because it contains PII (personally identifiable information), the SBA data is not included in the code repository. The data includes:
+
+* Extracts from JAAMS, SBA's financial system
+* Extracts from Prism, SBA's awards system
 
 These extracts will be supplemented by calls to the [SAM API](https://gsa.github.io/sam_api/sam/index.html), which contains details about entities (businesses and individuals) that receive federal funds.
 
 ### Data Structure
-For reference, the data accessed in the code are structured as follows:
+For reference, the data accessed in the code are structured as follows. The text files are extracts from their respective underlying databases and have been provided to the team in comma-quote delimited format.
 
-* `data/data_act_prism_grants_fy14.csv`: prism data combined into a single .csv (this is what we're using but the smaller files in data/prism are included for reference)
 * `data/jaams`: text file extracts from JAAMS
-* `data/jaams/sql`: sql for jaams table creation/joins
+* `data/jaams/sql`: sql for JAAMS table creation/joins
 * `data/prism`: text file extracts from Prism
-* `data/prism/sql`: prism create table scripts
+* `data/prism/sql`: sql for Prism table creation/joins
 
+### Running the Processor
+[INSTALL.md](INSTALL.md "Installation instructions") has more information about installing and running the processor.  
 
-### Running the Processor 
-
-The processor converts raw SBA data into text protocol buffers in the draft data act schema. The mapping from the schema to the SBA data can be found in `mappings/sba.py`. 
+The processor converts raw SBA data into text protocol buffers in the draft data act schema. The mapping from the schema to the SBA data can be found in `mappings/sba.py`.
 
 Example usage:
 
 `python processors/process_sba.py -i data/data_act.csv -o data/output_sba_pb`
-

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,11 @@
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.provision :shell, path: "bootstrap.sh"
+  config.vm.network "forwarded_port", guest: 5000, host: 5050
+  config.vm.network "forwarded_port", guest: 8888, host: 8889
+
+  # Add memory (needed to install Pandas, munge data, etc.)
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 1024
+  end
+end

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+apt-get update
+apt-get install git -y
+apt-get install python-dev -y
+apt-get install python-pip -y
+apt-get install libffi-dev -y
+
+# Add Postgres repository to apt
+cd /etc/apt/sources.list.d/
+sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > pgdg.list'
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+sudo apt-get update
+sudo apt-get upgrade -y
+
+# Install the Postgresql 9.4 packages
+sudo apt-get install postgresql-9.4 -y
+sudo apt-get install postgresql-contrib-9.4 -y
+
+apt-get install python-psycopg2 -y
+apt-get install libpq-dev -y
+
+pip install virtualenv
+pip install virtualenvwrapper
+
+sudo su vagrant <<'EOF'
+mkdir ~/.virtualenvs
+echo "export WORKON_HOME=~/.virtualenvs" >> ~/.bashrc
+echo "export VIRTUALENVWRAPPER_VIRTUALENV=/usr/local/bin/virtualenv" >> ~/.bashrc
+echo "source /usr/local/bin/virtualenvwrapper.sh" >> ~/.bashrc
+source ~/.bashrc
+source /usr/local/bin/virtualenvwrapper.sh
+mkvirtualenv intercessor
+pip install -r /vagrant/requirements.txt
+EOF

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
+pyopenssl
 pandas==0.16.0
 ipython[notebook]
 protobuf
 requests
 beautifulsoup4
 unidecode
-pyopenssl
 ndg-httpsclient
 pyasn1


### PR DESCRIPTION
Given that a federal audience is likely to be running Windows, thought it would be best to use Vagrant for the install instructions (similar to what we did in the workshop). 

Thought about also adding a section for setting up without using a virtual machine. Happy to do that but would want to be clear that Windows users should not attempt unless they're already adept at configuring Python environments on that OS.

PS. Copied the Vagrantfile and boostrap.sh from our workshop repo, so they install a few things that we don't need for the pilot (postgres). I left them there.