### PR TITLE
A few fixes for the project Vagrant box

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -44,15 +44,19 @@ From the command line:
 
 5. Install [Vagrant](http://www.vagrantup.com/downloads.html "Vagrant downloads")  
 
-6. From project root directory, run:
+6. Open _bootstrap.sh_ (in the project root directory), find the string that reads `YOUR_SAM_API_KEY` and replace it with your SAM API key. If you don't have a key, you can get one in less than a minute by signing up at [https://gsa.github.io/sam_api/sam/key](https://gsa.github.io/sam_api/sam/key "SAM API Key").
+
+        echo "export DOT_GOV_API_KEY='YOUR_SAM_API_KEY'" >> ~/.bashrc
+
+7. From project root directory, run:
 
          $ vagrant up
 
-7. Once the VM is fully started and provisioned (~15 minutes), connect to it with:
+8. Once the VM is fully started and provisioned (~15 minutes), connect to it with:
 
         $ vagrant ssh
 
-8. The project directory on your host machine is shared with the VM at `/vagrant`. Navigate there to run the processors.
+9. The project directory on your host machine is shared with the VM at `/vagrant`. Navigate there to run the processors.
 
         $ cd /vagrant
         $ workon intercessor

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For reference, the data accessed in the code are structured as follows. The text
 ### Running the Processors
 These directions assume that the project is already installed on your system. If you don't have the project installed and running, please see [INSTALL.md](INSTALL.md "Installation instructions").
 
-There are two processes that convert SBA data to DATA Act format. 
+There are two processes that convert SBA data to DATA Act format.
 
 The first reads raw text files from SBA (JAAMS and Prism) and combines them into a single file of awards+modifications (what the [draft schema](https://raw.githubusercontent.com/18F/intercessor/master/schema/data-act-schema.png) calls an _action_).
 
@@ -55,6 +55,7 @@ The second converts that combined data into text protocol buffers in the draft d
 Example usage (to run both processes):
 
 `python processors/process_source.py -o data/data_act.csv`
+
 `python processors/process_sba.py -i data/data_act.csv -o data/output_sba_pb`
 
 ### Querying the SAM api

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure(2) do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "ubuntu/vivid64"
   config.vm.provision :shell, path: "bootstrap.sh"
   config.vm.network "forwarded_port", guest: 5000, host: 5050
   config.vm.network "forwarded_port", guest: 8888, host: 8889

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -27,6 +27,8 @@ sudo su vagrant <<'EOF'
 mkdir ~/.virtualenvs
 echo "export WORKON_HOME=~/.virtualenvs" >> ~/.bashrc
 echo "export VIRTUALENVWRAPPER_VIRTUALENV=/usr/local/bin/virtualenv" >> ~/.bashrc
+echo "export DOT_GOV_API_KEY='YOUR_SAM_API_KEY'" >> ~/.bashrc
+echo "export PYTHONPATH=/vagrant" >> ~/.bashrc
 echo "source /usr/local/bin/virtualenvwrapper.sh" >> ~/.bashrc
 source ~/.bashrc
 source /usr/local/bin/virtualenvwrapper.sh

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,20 +5,7 @@ apt-get install git -y
 apt-get install python-dev -y
 apt-get install python-pip -y
 apt-get install libffi-dev -y
-
-# Add Postgres repository to apt
-cd /etc/apt/sources.list.d/
-sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > pgdg.list'
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-sudo apt-get update
-sudo apt-get upgrade -y
-
-# Install the Postgresql 9.4 packages
-sudo apt-get install postgresql-9.4 -y
-sudo apt-get install postgresql-contrib-9.4 -y
-
-apt-get install python-psycopg2 -y
-apt-get install libpq-dev -y
+apt-get install libssl-dev -y
 
 pip install virtualenv
 pip install virtualenvwrapper


### PR DESCRIPTION
* add environment variables for PYTHONPATH and SAM API key
* bump Ubuntu base box to 15.04 (which in turn bumps to Python 2.7.9 & fixes the urllib3 insecure platform warning)
* remove the Postgres db, since we're not using it